### PR TITLE
bugfix - fixed typo in accessing language parameter in Recaptcha type constructor

### DIFF
--- a/Form/Type/VihuvacRecaptchaType.php
+++ b/Form/Type/VihuvacRecaptchaType.php
@@ -71,7 +71,7 @@ class VihuvacRecaptchaType extends AbstractType
         $this->siteKey  = $container->getParameter("vihuvac_recaptcha.site_key");
         $this->secure   = $container->getParameter("vihuvac_recaptcha.secure");
         $this->enabled  = $container->getParameter("vihuvac_recaptcha.enabled");
-        $this->language = $container->getParameter($container->getParameter("vihuvac_recaptcha.locale_key"));
+        $this->language = $container->getParameter("vihuvac_recaptcha.locale_key");
     }
 
     /**


### PR DESCRIPTION
Trying to read language parameter value as a parameter variable in `Vihuvac\Bundle\RecaptchaBundle\Form\Type\VihuvacRecaptchaType::__construct`.
