### PR TITLE
fix google validation

### DIFF
--- a/Validator/Constraints/IsTrueValidator.php
+++ b/Validator/Constraints/IsTrueValidator.php
@@ -137,7 +137,7 @@ class IsTrueValidator extends ConstraintValidator
 	 */
 	private function httpGet($host, $path, $data)
 	{
-		$host = sprintf("%s%s?%s", $host, $path, http_build_query($data));
+		$host = sprintf("%s%s?%s", $host, $path, http_build_query($data, null, '&'));
 
 		$context = $this->getResourceContext();
 


### PR DESCRIPTION
google validation was not working on some servers, because `http_build_query` on some servers use "&" and sometimes "&amp;" and "&amp;" doesn't work.