### PR TITLE
fix validation without seen captcha

### DIFF
--- a/Validator/Constraints/IsTrueValidator.php
+++ b/Validator/Constraints/IsTrueValidator.php
@@ -105,11 +105,13 @@ class IsTrueValidator extends ConstraintValidator
             throw new ValidatorException("vihuvac_recaptcha.validator.remote_ip");
         }
 
-        // discard spam submissions
-        if ($response == null || strlen($response) == 0) {
-            return false;
+        if ($response === null) { // wasn't show before send
+            return true;
         }
 
+        if ((string)$response === "") { // wasn't checked by robot
+            return false;
+        }
 
 	    $response = $this->httpGet(self::RECAPTCHA_VERIFY_SERVER, "/recaptcha/api/siteverify", array(
 		    "secret"   => $secretKey,


### PR DESCRIPTION
Hi, 

when I am using this bundle with flow written below, validation of captcha is executed without previous input render.

Flow:

I have form, where I valid my inputs to be filled. After few failed attempts I want to show captcha. But when I add captcha first time, then previous form post valid this captcha.